### PR TITLE
Added Help and Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Now you can use available recipes too or create your owns and publish it [here](
 
 | Command | Alias | Description |
 | --- | --- | --- |
-| `uni bake daltonmenezes/atom-install` | `uni b daltonmenezes/atom-install`  | Installs the latest version of<br/>Atom Editor from their<br/>official website and resolve<br/>dependency issues. |
+| `uni bake atom-install` | `uni b atom-install`  | Installs the latest version of<br/>Atom Editor from their<br/>official website and resolve<br/>dependency issues. |
 
 [Check here the list of available recipes for usage.](https://github.com/uni-linux/recipes)
+You can also type `uni --recipes` to fetch the current list of recipes from GitHub and display in your terminal.
 
 # Installation
 

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -13,6 +13,8 @@ All commands uses `-y` by default, except `uni remove`, so you don't need to put
 | `uni upgrade-me` | `uni up-me`  | Looks for UNI upgrades, if available it will be upgraded. |
 | `uni remove-me` | `uni rm-me`  | Removes UNI from the system. |
 | `uni --version` | `uni -v`  | Shows the current UNI version installed. |
+| `uni --recipes` | `uni -r`  | Shows available recipes in the UNI GitHub. |
+| `uni --help` | `uni -h`  | Shows available UNI commands and usage. |
 
 # Package manager abstractions
 

--- a/src/tools/bake
+++ b/src/tools/bake
@@ -1,6 +1,12 @@
 #!/bin/bash
 function bake {
-  for recipe in $recipes; do
+  for recipeVar in $recipes; do
+      if [[ "$recipeVar" != */* ]]; then
+        recipe="daltonmenezes/${recipeVar}"
+        printf "Using default ${STYLE_CYAN}daltonmenezes${RESET_STYLE}\n\n"
+      else
+        recipe=${recipeVar}
+      fi
       get_recipe_info_from_github=`wget -O .bake_temp.txt https://raw.githubusercontent.com/uni-linux/recipes/master/src/$recipe/README.md -q`
       get_recipe_info=`cat .bake_temp.txt`
       recipe_name=`grep -Po -m 1 '[^\#\s].*$' <<< "$get_recipe_info"`

--- a/src/tools/bake_how
+++ b/src/tools/bake_how
@@ -1,6 +1,12 @@
 #!/bin/bash
 function bake_how {
-  for recipe in $recipes; do
+  for recipeVar in $recipes; do
+      if [[ "$recipeVar" != */* ]]; then
+        recipe="daltonmenezes/${recipeVar}"
+        printf "Using default ${STYLE_CYAN}daltonmenezes${RESET_STYLE}\n\n"
+      else
+        recipe=${recipeVar}
+      fi
       get_recipe_info_from_github=`wget -O .bake_temp.txt https://raw.githubusercontent.com/uni-linux/recipes/master/src/$recipe/README.md -q`
       get_recipe_info=`cat .bake_temp.txt`
       recipe_name=`grep -Po -m 1 '[^\#\s].*$' <<< "$get_recipe_info"`

--- a/uni
+++ b/uni
@@ -82,7 +82,7 @@ ${STYLE_BOLD}  rm-me, remove-me${RESET_STYLE}            Removes UNI from the sy
     --recipes | -r)
         # get README from github
         RECIPES_URL="https://raw.githubusercontent.com/uni-linux/recipes/master/src/daltonmenezes/README.md"
-        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g' -e '/> username: daltonmenezes/,/# My Recipes/c\username:\\e[36m datonmenezes\\n\\n\\e[1mRecipes\\e[0m' -e 's/([^()]*)//g')"
+        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g' -e '/> username: daltonmenezes/,/# My Recipes/c\username:\\e[36m daltonmenezes\\n\\n\\e[1mRecipes\\e[0m' -e 's/([^()]*)//g')"
         printf "${RECIPES_PAGE}\n\n";;
     *) printf "${STYLE_RED}\nThe ${RESET_STYLE}'$1'${STYLE_RED} argument doesn't exists. Beep...\n\n"; exit 0;;
   esac;

--- a/uni
+++ b/uni
@@ -82,7 +82,7 @@ ${STYLE_BOLD}  rm-me, remove-me${RESET_STYLE}            Removes UNI from the sy
     --recipes | -r)
         # get README from github
         RECIPES_URL="https://raw.githubusercontent.com/uni-linux/recipes/master/src/daltonmenezes/README.md"
-        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g')"
+        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g' -e '/> username: daltonmenezes/,/# My Recipes/c\username:\\e[36m datonmenezes\\n\\n\\e[1mRecipes\\e[0m' -e 's/([^()]*)//g')"
         printf "${RECIPES_PAGE}\n\n";;
     *) printf "${STYLE_RED}\nThe ${RESET_STYLE}'$1'${STYLE_RED} argument doesn't exists. Beep...\n\n"; exit 0;;
   esac;

--- a/uni
+++ b/uni
@@ -17,37 +17,45 @@ fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    # system updaate
     update | u | --update | -u)
         . /usr/share/uni/src/$operating_system/update.sh
         update
     ;;
+    # system upgrade
     upgrade | up | --upgrade | -up)
         . /usr/share/uni/src/$operating_system/upgrade.sh
         upgrade
     ;;
+    # upgrade UNI
     upgrade-me | up-me | --upgrade-me | -up-me)
         . /usr/share/uni/src/tools/upgrade
         upgradeUni
     ;;
+    # remove UNI
     remove-me | rm-me | --remove-me | -rm-me)
         . /usr/share/uni/src/tools/remove
         removeUni
     ;;
+    # remove a package or recipe
     remove | rm | --remove | -rm)
         . /usr/share/uni/src/$operating_system/remove.sh
         package="${@:2}"
         remove
     ;;
+    # add a repo
     add | a | --add | -a)
         . /usr/share/uni/src/$operating_system/add.sh
         repo="${@:2}"
         add
     ;;
+    # install a package
     install | i | --install | -i)
         . /usr/share/uni/src/$operating_system/install.sh
         package="${@:2}"
         install
     ;;
+    # bake a recipe
     bake | b | --bake | -b)
         if [ "$2" == "how" ]; then
             . /usr/share/uni/src/tools/bake_how
@@ -58,16 +66,24 @@ while [ "$#" -gt 0 ]; do
             bake
         fi
     ;;
+    # check version
     --version | -v) printf "${STYLE_LIGHT_CYAN}\n UNI${STYLE_BOLD} v${uni_version}\n\n";;
+    # get current list of recipes from github
+    --recipes | -r)
+        # get README from github
+        RECIPES_URL="https://raw.githubusercontent.com/uni-linux/recipes/master/src/daltonmenezes/README.md"
+        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g' -e '/> username: daltonmenezes/,/# My Recipes/c\username:\\e[36m daltonmenezes\\n\\n\\e[1mRecipes\\e[0m' -e 's/([^()]*)//g')"
+        printf "${RECIPES_PAGE}\n\n";;
+    # display usage info
     --help | help | -h | h)
         HELP_INFO="
 ${STYLE_LIGHT_CYAN}${STYLE_BOLD}Usage: ${RESET_STYLE}${STYLE_BOLD}uni [OPTIONS]
 
 ${STYLE_LIGHT_CYAN}Options:${RESET_STYLE}
 ${STYLE_BOLD}  -h, --help${RESET_STYLE}                  Shows available commands
-${STYLE_BOLD}  -v, --version${RESET_STYLE}               Shows the current UNI version installed.
-${STYLE_BOLD}  -r, --recipes${RESET_STYLE}               Shows available github recipes.
-${STYLE_BOLD}  a, add${RESET_STYLE}                      Adds one or more repositories.
+${STYLE_BOLD}  -v, --version${RESET_STYLE}               Shows the current UNI version installed
+${STYLE_BOLD}  -r, --recipes${RESET_STYLE}               Shows available recipes in the UNI GitHub
+${STYLE_BOLD}  a, add${RESET_STYLE}                      Adds one or more repositories
 ${STYLE_BOLD}  b, bake ${STYLE_YELLOW}<recipe>${RESET_STYLE}            Cooks one or more given recipes
 ${STYLE_BOLD}  b how, bake how ${STYLE_YELLOW}<recipe>${RESET_STYLE}    Shows what one or more recipes does
 ${STYLE_BOLD}  i, install ${STYLE_YELLOW}<package>${RESET_STYLE}        Installs one or more packages
@@ -79,11 +95,7 @@ ${STYLE_BOLD}  rm-me, remove-me${RESET_STYLE}            Removes UNI from the sy
 
 "
         printf "${HELP_INFO}";;
-    --recipes | -r)
-        # get README from github
-        RECIPES_URL="https://raw.githubusercontent.com/uni-linux/recipes/master/src/daltonmenezes/README.md"
-        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g' -e '/> username: daltonmenezes/,/# My Recipes/c\username:\\e[36m daltonmenezes\\n\\n\\e[1mRecipes\\e[0m' -e 's/([^()]*)//g')"
-        printf "${RECIPES_PAGE}\n\n";;
+    # unexpected argument
     *) printf "${STYLE_RED}\nThe ${RESET_STYLE}'$1'${STYLE_RED} argument doesn't exists. Beep...\n\n"; exit 0;;
   esac;
   exit 0

--- a/uni
+++ b/uni
@@ -17,38 +17,38 @@ fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    update | u)
+    update | u | --update | -u)
         . /usr/share/uni/src/$operating_system/update.sh
         update
     ;;
-    upgrade | up)
+    upgrade | up | --upgrade | -up)
         . /usr/share/uni/src/$operating_system/upgrade.sh
         upgrade
     ;;
-    upgrade-me | up-me)
+    upgrade-me | up-me | --upgrade-me | -up-me)
         . /usr/share/uni/src/tools/upgrade
         upgradeUni
     ;;
-    remove-me | rm-me)
+    remove-me | rm-me | --remove-me | -rm-me)
         . /usr/share/uni/src/tools/remove
         removeUni
     ;;
-    remove | rm)
+    remove | rm | --remove | -rm)
         . /usr/share/uni/src/$operating_system/remove.sh
         package="${@:2}"
         remove
     ;;
-    add | a)
+    add | a | --add | -a)
         . /usr/share/uni/src/$operating_system/add.sh
         repo="${@:2}"
         add
     ;;
-    install | i)
+    install | i | --install | -i)
         . /usr/share/uni/src/$operating_system/install.sh
         package="${@:2}"
         install
     ;;
-    bake | b)
+    bake | b | --bake | -b)
         if [ "$2" == "how" ]; then
             . /usr/share/uni/src/tools/bake_how
             recipes="${@:3}"
@@ -59,6 +59,34 @@ while [ "$#" -gt 0 ]; do
         fi
     ;;
     --version | -v) printf "${STYLE_LIGHT_CYAN}\n UNI${STYLE_BOLD} v${uni_version}\n\n";;
+    --help | help | -h | h)
+        HELP_INFO="
+${STYLE_LIGHT_CYAN}${STYLE_BOLD}Usage: ${RESET_STYLE}${STYLE_BOLD}uni [OPTIONS]
+
+${STYLE_LIGHT_CYAN}Options:${RESET_STYLE}
+${STYLE_BOLD}  -h, --help${RESET_STYLE}                  Shows available commands
+${STYLE_BOLD}  -v, --version${RESET_STYLE}               Shows the current UNI version installed.
+${STYLE_BOLD}  a, add${RESET_STYLE}                      Adds one or more repositories.
+${STYLE_BOLD}  b, bake ${STYLE_YELLOW}<recipe>${RESET_STYLE}            Cooks one or more given recipes
+${STYLE_BOLD}  b how, bake how ${STYLE_YELLOW}<recipe>${RESET_STYLE}    Shows what one or more recipes does
+${STYLE_BOLD}  i, install ${STYLE_YELLOW}<package>${RESET_STYLE}        Installs one or more packages
+${STYLE_BOLD}  u, update${RESET_STYLE}                   Updates the package lists from your repositories
+${STYLE_BOLD}  up, upgrade${RESET_STYLE}                 Upgrades deeply the system and remove useless dependencies
+${STYLE_BOLD}  up-me, upgrade-me${RESET_STYLE}           Looks for UNI upgrades, if available it will be upgraded
+${STYLE_BOLD}  rm, remove ${STYLE_YELLOW}<package>${RESET_STYLE}        Removes one or more packages
+${STYLE_BOLD}  rm-me, remove-me${RESET_STYLE}            Removes UNI from the system
+
+${STYLE_LIGHT_CYAN}Available Recipes (by Dalton Menezes):${RESET_STYLE}
+${STYLE_YELLOW}  atom-install${RESET_STYLE}                Installs the latest version of Atom Editor
+${STYLE_YELLOW}  telegram-install${RESET_STYLE}            Installs the latest version of Telegram
+${STYLE_YELLOW}  node-install${RESET_STYLE}                Installs the nodejs latest LTS available version and npm
+${STYLE_YELLOW}  yarn-install${RESET_STYLE}                Installs the latest version of Yarn
+${STYLE_YELLOW}  stylishbuntu-theme${RESET_STYLE}          Theme Package
+${STYLE_YELLOW}  nebulosa-theme${RESET_STYLE}              Theme Package
+${STYLE_YELLOW}  mac-theme${RESET_STYLE}                   Theme Package
+
+"
+        printf "${HELP_INFO}";;
     *) printf "${STYLE_RED}\nThe ${RESET_STYLE}'$1'${STYLE_RED} argument doesn't exists. Beep...\n\n"; exit 0;;
   esac;
   exit 0

--- a/uni
+++ b/uni
@@ -66,6 +66,7 @@ ${STYLE_LIGHT_CYAN}${STYLE_BOLD}Usage: ${RESET_STYLE}${STYLE_BOLD}uni [OPTIONS]
 ${STYLE_LIGHT_CYAN}Options:${RESET_STYLE}
 ${STYLE_BOLD}  -h, --help${RESET_STYLE}                  Shows available commands
 ${STYLE_BOLD}  -v, --version${RESET_STYLE}               Shows the current UNI version installed.
+${STYLE_BOLD}  -r, --recipes${RESET_STYLE}               Shows available github recipes.
 ${STYLE_BOLD}  a, add${RESET_STYLE}                      Adds one or more repositories.
 ${STYLE_BOLD}  b, bake ${STYLE_YELLOW}<recipe>${RESET_STYLE}            Cooks one or more given recipes
 ${STYLE_BOLD}  b how, bake how ${STYLE_YELLOW}<recipe>${RESET_STYLE}    Shows what one or more recipes does
@@ -76,17 +77,13 @@ ${STYLE_BOLD}  up-me, upgrade-me${RESET_STYLE}           Looks for UNI upgrades,
 ${STYLE_BOLD}  rm, remove ${STYLE_YELLOW}<package>${RESET_STYLE}        Removes one or more packages
 ${STYLE_BOLD}  rm-me, remove-me${RESET_STYLE}            Removes UNI from the system
 
-${STYLE_LIGHT_CYAN}Available Recipes (by Dalton Menezes):${RESET_STYLE}
-${STYLE_YELLOW}  atom-install${RESET_STYLE}                Installs the latest version of Atom Editor
-${STYLE_YELLOW}  telegram-install${RESET_STYLE}            Installs the latest version of Telegram
-${STYLE_YELLOW}  node-install${RESET_STYLE}                Installs the nodejs latest LTS available version and npm
-${STYLE_YELLOW}  yarn-install${RESET_STYLE}                Installs the latest version of Yarn
-${STYLE_YELLOW}  stylishbuntu-theme${RESET_STYLE}          Theme Package
-${STYLE_YELLOW}  nebulosa-theme${RESET_STYLE}              Theme Package
-${STYLE_YELLOW}  mac-theme${RESET_STYLE}                   Theme Package
-
 "
         printf "${HELP_INFO}";;
+    --recipes | -r)
+        # get README from github
+        RECIPES_URL="https://raw.githubusercontent.com/uni-linux/recipes/master/src/daltonmenezes/README.md"
+        RECIPES_PAGE="$(wget -q -O - ${RECIPES_URL} | sed -e 's/<[^>]*>//g' -e 's/- \[/ \\e[33m /g' -e 's/\]/ \\e[0m /g')"
+        printf "${RECIPES_PAGE}\n\n";;
     *) printf "${STYLE_RED}\nThe ${RESET_STYLE}'$1'${STYLE_RED} argument doesn't exists. Beep...\n\n"; exit 0;;
   esac;
   exit 0


### PR DESCRIPTION
- Add `uni --help` to provide available use options in CLI
- Assume default recipe owner if not provided (since there's currently only one, anyway) for ease of typing -- allows typing just `uni bake yarn-install` for example

![image](https://user-images.githubusercontent.com/55799997/79211103-6015c180-7e0b-11ea-9cc4-cc0cd16203f9.png)
